### PR TITLE
fix: PM review round 2 — logo, npm size, 405, sitemap

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vnsh-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "mcpName": "io.github.raullenchai/vnsh",
   "description": "MCP server for vnsh - secure content sharing for Claude Code",
   "keywords": [
@@ -30,7 +30,10 @@
     "vnsh-mcp": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/crypto.js",
+    "dist/crypto.d.ts"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Round 2 Fixes

### 🔴 P0
- **npm package 71% smaller**: Added `files` whitelist, excluded test files (81.6KB → 23.7KB). Bump to 1.1.1
- **`/logo.svg` route**: Fixes broken image in README header

### 🟡 P1
- **`/v/` accepts any path**: Was rejecting non-UUID strings with 404, now serves viewer (JS handles errors)
- **`GET /api/drop` → 405**: Was returning generic 404, now returns proper Method Not Allowed

### 🟢 P2
- **Sitemap**: Added `/pipe` page

### Testing
- 127 MCP tests pass ✅
- Worker deployed, all endpoints verified ✅
- npm pack dry-run confirms only 4 files shipped ✅