### PR TITLE
Portable workspaces (v2 Phase 0) + 24h expiry fix

### DIFF
--- a/mcp/src/crypto.test.ts
+++ b/mcp/src/crypto.test.ts
@@ -12,7 +12,14 @@ import {
   bufferToHex,
   parseVnshUrl,
   buildVnshUrl,
+  generateRootSecret,
+  deriveWorkspaceKeys,
+  encryptWorkspace,
+  decryptWorkspace,
+  buildWorkspaceUrl,
+  parseWorkspaceUrl,
 } from './crypto.js';
+import { createHash } from 'crypto';
 
 describe('generateKey', () => {
   it('generates a 32-byte key', () => {
@@ -234,5 +241,89 @@ describe('OpenSSL compatibility', () => {
     expect(ciphertext.length).toBeGreaterThanOrEqual(16);
     // The ciphertext length should be a multiple of 16 (AES block size)
     expect(ciphertext.length % 16).toBe(0);
+  });
+});
+
+describe('workspace crypto (v2)', () => {
+  it('round-trips content through AES-256-GCM', () => {
+    const secret = generateRootSecret();
+    const { key } = deriveWorkspaceKeys(secret);
+    const plaintext = 'multi-agent workspace content 中文 🔑';
+
+    const payload = encryptWorkspace(plaintext, key);
+    expect(decryptWorkspace(payload, key).toString('utf-8')).toBe(plaintext);
+  });
+
+  it('derives deterministically from the root secret', () => {
+    const secret = generateRootSecret();
+    const a = deriveWorkspaceKeys(secret);
+    const b = deriveWorkspaceKeys(secret);
+
+    expect(a.key.toString('hex')).toBe(b.key.toString('hex'));
+    expect(a.writeToken).toBe(b.writeToken);
+    expect(a.writeHash).toBe(b.writeHash);
+  });
+
+  it('keeps the content key and write token independent', () => {
+    const { key, writeToken } = deriveWorkspaceKeys(generateRootSecret());
+    expect(key.toString('hex')).not.toBe(writeToken);
+  });
+
+  it('computes writeHash the way the worker does: SHA-256 over the hex string', () => {
+    const { writeToken, writeHash } = deriveWorkspaceKeys(generateRootSecret());
+    // The worker runs sha256Hex(header), which UTF-8 encodes the header text.
+    // Hashing the raw bytes instead would silently break every write.
+    const expected = createHash('sha256').update(writeToken, 'utf-8').digest('hex');
+    expect(writeHash).toBe(expected);
+    expect(writeToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(writeHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('uses a fresh nonce per write, so identical plaintext yields different bytes', () => {
+    const { key } = deriveWorkspaceKeys(generateRootSecret());
+    const a = encryptWorkspace('same', key);
+    const b = encryptWorkspace('same', key);
+
+    expect(a.subarray(0, 12).toString('hex')).not.toBe(b.subarray(0, 12).toString('hex'));
+    expect(a.toString('hex')).not.toBe(b.toString('hex'));
+  });
+
+  it('rejects tampered ciphertext', () => {
+    const { key } = deriveWorkspaceKeys(generateRootSecret());
+    const payload = encryptWorkspace('trusted content', key);
+    payload[payload.length - 20] ^= 0xff; // flip a bit inside the ciphertext
+
+    expect(() => decryptWorkspace(payload, key)).toThrow();
+  });
+
+  it('rejects the wrong key', () => {
+    const payload = encryptWorkspace('secret', deriveWorkspaceKeys(generateRootSecret()).key);
+    const other = deriveWorkspaceKeys(generateRootSecret()).key;
+
+    expect(() => decryptWorkspace(payload, other)).toThrow();
+  });
+
+  it('rejects a truncated payload', () => {
+    const { key } = deriveWorkspaceKeys(generateRootSecret());
+    expect(() => decryptWorkspace(Buffer.alloc(8), key)).toThrow(/too short/);
+  });
+
+  it('round-trips a workspace URL', () => {
+    const secret = generateRootSecret();
+    const url = buildWorkspaceUrl('https://vnsh.dev', 'aBcDeFgHiJkL', secret);
+
+    expect(url).toMatch(/^https:\/\/vnsh\.dev\/w\/aBcDeFgHiJkL#w=[A-Za-z0-9_-]+$/);
+
+    const parsed = parseWorkspaceUrl(url);
+    expect(parsed.host).toBe('https://vnsh.dev');
+    expect(parsed.id).toBe('aBcDeFgHiJkL');
+    expect(parsed.secret.toString('hex')).toBe(secret.toString('hex'));
+  });
+
+  it('rejects malformed workspace URLs', () => {
+    const secret = generateRootSecret().toString('base64url');
+    expect(() => parseWorkspaceUrl('https://vnsh.dev/w/aBcDeFgHiJkL')).toThrow(/fragment/);
+    expect(() => parseWorkspaceUrl(`https://vnsh.dev/v/aBcDeFgHiJkL#w=${secret}`)).toThrow(/\/w\//);
+    expect(() => parseWorkspaceUrl('https://vnsh.dev/w/aBcDeFgHiJkL#w=c2hvcnQ')).toThrow(/32 bytes/);
   });
 });

--- a/mcp/src/crypto.ts
+++ b/mcp/src/crypto.ts
@@ -169,3 +169,104 @@ export function buildVnshUrl(host: string, id: string, key: Buffer, iv: Buffer):
   const secretBase64url = bufferToBase64url(secret);
   return `${host}/v/${id}#${secretBase64url}`;
 }
+
+// ---------------------------------------------------------------------------
+// Workspace crypto (v2) — AES-256-GCM with a random per-write nonce.
+//
+// A single root secret S lives only in the URL fragment. Everything else is
+// derived from it, so the server can verify writes without ever being able to
+// decrypt:
+//
+//   K = HKDF(S, "vnsh/enc/v2")     content key
+//   W = HKDF(S, "vnsh/write/v2")   write token, sent as 64 hex chars
+//   H = SHA-256(W)                 the only derived value the server stores
+//
+// GCM is used rather than CBC because workspace content is mutable: without an
+// authentication tag, anyone able to rewrite storage (including the host) could
+// flip ciphertext bits undetectably.
+//
+// The nonce is random per write and prepended to the ciphertext rather than
+// derived from a version number. Reusing a nonce under GCM leaks the
+// authentication key, not just plaintext — and a fresh random 96-bit nonce per
+// write makes reuse impossible without any version bookkeeping on the client.
+// ---------------------------------------------------------------------------
+
+import { createHash, hkdfSync } from 'crypto';
+
+const GCM_NONCE_BYTES = 12;
+const GCM_TAG_BYTES = 16;
+
+export function generateRootSecret(): Buffer {
+  return randomBytes(32);
+}
+
+function derive(secret: Buffer, info: string): Buffer {
+  return Buffer.from(hkdfSync('sha256', secret, Buffer.alloc(0), Buffer.from(info, 'utf-8'), 32));
+}
+
+export interface WorkspaceKeys {
+  /** AES-256-GCM content key. */
+  key: Buffer;
+  /** Write token, as the 64 hex chars sent in X-Vnsh-Write. */
+  writeToken: string;
+  /** SHA-256 of the write token — what the server stores and compares. */
+  writeHash: string;
+}
+
+export function deriveWorkspaceKeys(secret: Buffer): WorkspaceKeys {
+  const key = derive(secret, 'vnsh/enc/v2');
+  const writeToken = derive(secret, 'vnsh/write/v2').toString('hex');
+  // Must hash the hex *string*, matching the worker's
+  // sha256Hex(header) which encodes the header text as UTF-8.
+  const writeHash = createHash('sha256').update(writeToken, 'utf-8').digest('hex');
+  return { key, writeToken, writeHash };
+}
+
+/** Encrypt to `nonce ‖ ciphertext ‖ tag`. */
+export function encryptWorkspace(plaintext: string | Buffer, key: Buffer): Buffer {
+  const nonce = randomBytes(GCM_NONCE_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  const input = typeof plaintext === 'string' ? Buffer.from(plaintext, 'utf-8') : plaintext;
+  const ciphertext = Buffer.concat([cipher.update(input), cipher.final()]);
+  return Buffer.concat([nonce, ciphertext, cipher.getAuthTag()]);
+}
+
+/** Decrypt `nonce ‖ ciphertext ‖ tag`. Throws if the tag does not verify. */
+export function decryptWorkspace(payload: Buffer, key: Buffer): Buffer {
+  if (payload.length < GCM_NONCE_BYTES + GCM_TAG_BYTES) {
+    throw new Error('Workspace payload is too short to be valid');
+  }
+  const nonce = payload.subarray(0, GCM_NONCE_BYTES);
+  const tag = payload.subarray(payload.length - GCM_TAG_BYTES);
+  const ciphertext = payload.subarray(GCM_NONCE_BYTES, payload.length - GCM_TAG_BYTES);
+
+  const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/** `https://host/w/{id}#w={base64url(S)}` */
+export function buildWorkspaceUrl(host: string, id: string, secret: Buffer): string {
+  return `${host}/w/${id}#w=${bufferToBase64url(secret)}`;
+}
+
+export function parseWorkspaceUrl(url: string): { host: string; id: string; secret: Buffer } {
+  const [urlPart, fragment] = url.split('#');
+  if (!fragment) {
+    throw new Error('Invalid workspace URL: missing #w= fragment');
+  }
+
+  const urlObj = new URL(urlPart);
+  const pathMatch = urlObj.pathname.match(/^\/w\/([0-9A-Za-z]{12})$/);
+  if (!pathMatch) {
+    throw new Error('Invalid workspace URL: expected a /w/{id} path');
+  }
+
+  const encoded = fragment.startsWith('w=') ? fragment.slice(2) : fragment;
+  const secret = base64urlToBuffer(encoded);
+  if (secret.length !== 32) {
+    throw new Error(`Invalid workspace URL: secret must be 32 bytes (got ${secret.length})`);
+  }
+
+  return { host: urlObj.origin, id: pathMatch[1], secret };
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -9,6 +9,7 @@
  * - vnsh_read: Decrypt and read content from a vnsh URL
  * - vnsh_share: Encrypt and upload text content, return shareable URL
  * - vnsh_share_file: Encrypt and upload a local file, return shareable URL
+ * - vnsh_workspace_create/read/update/open: mutable, versioned shared workspaces
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -31,6 +32,12 @@ import {
   parseVnshUrl,
   buildVnshUrl,
   bufferToHex,
+  generateRootSecret,
+  deriveWorkspaceKeys,
+  encryptWorkspace,
+  decryptWorkspace,
+  buildWorkspaceUrl,
+  parseWorkspaceUrl,
 } from './crypto.js';
 
 // Configuration
@@ -53,6 +60,21 @@ const ShareFileInputSchema = z.object({
   file_path: z.string().describe('Absolute path to the file to encrypt and share'),
   ttl: z.number().optional().describe('Time-to-live in hours (default: 24, max: 168)'),
   host: z.string().optional().describe('Override the vnsh host URL'),
+});
+
+const WorkspaceCreateSchema = z.object({
+  content: z.string().describe('Initial workspace content'),
+  host: z.string().optional(),
+});
+
+const WorkspaceUrlSchema = z.object({
+  url: z.string().describe('Full workspace URL including the #w= fragment'),
+});
+
+const WorkspaceUpdateSchema = z.object({
+  url: z.string(),
+  content: z.string(),
+  base_version: z.number().optional(),
 });
 
 // Create MCP server
@@ -141,6 +163,80 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ['file_path'],
         },
       },
+      {
+        name: 'vnsh_workspace_create',
+        description:
+          'Creates a shared workspace and returns one link that any agent can read AND write. ' +
+          'Use this when work will continue somewhere else: handing a plan, status doc, ' +
+          'design, or investigation to another agent or another session, or when the user ' +
+          'says they will pick this up in a different tool. Unlike vnsh_share (a one-shot ' +
+          'snapshot), a workspace keeps the same URL as its content evolves. ' +
+          'Content is encrypted locally; the server never sees the key. Expires 24h after ' +
+          'the last write.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            content: {
+              type: 'string',
+              description: 'Initial content. HTML renders as a page via vnsh_workspace_open.',
+            },
+            host: { type: 'string', description: 'Override the vnsh host URL' },
+          },
+          required: ['content'],
+        },
+      },
+      {
+        name: 'vnsh_workspace_read',
+        description:
+          'Reads the current content of a vnsh workspace URL (a /w/ link with a #w= fragment). ' +
+          'Use this whenever the user provides such a link — it is how you pick up work another ' +
+          'agent left for you. Returns the content and its version number; pass that version to ' +
+          'vnsh_workspace_update to write safely.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            url: { type: 'string', description: 'Full workspace URL including the #w= fragment' },
+          },
+          required: ['url'],
+        },
+      },
+      {
+        name: 'vnsh_workspace_update',
+        description:
+          'Replaces the content of a vnsh workspace, keeping the same URL. Use this to record ' +
+          'progress so far, revise a shared plan, or leave the next agent an updated document. ' +
+          'Writes are version-checked: if someone else wrote first, this returns their current ' +
+          'content so you can merge it with yours and call this again.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            url: { type: 'string', description: 'Full workspace URL including the #w= fragment' },
+            content: { type: 'string', description: 'The full new content (replaces everything)' },
+            base_version: {
+              type: 'number',
+              description:
+                'Version this edit is based on. Omit to read the latest first. Pass the version ' +
+                'from vnsh_workspace_read when you have already merged against it.',
+            },
+          },
+          required: ['url', 'content'],
+        },
+      },
+      {
+        name: 'vnsh_workspace_open',
+        description:
+          'Decrypts a vnsh workspace to a local temp file and opens it in the browser. ' +
+          'Use this when the user wants to LOOK at a workspace rather than have its content ' +
+          'read into context — HTML reports, dashboards, and diagrams render properly this way. ' +
+          'Rendering happens locally from file://, so nothing is exposed to any server.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            url: { type: 'string', description: 'Full workspace URL including the #w= fragment' },
+          },
+          required: ['url'],
+        },
+      },
     ],
   };
 });
@@ -156,6 +252,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return await handleShare(args);
     } else if (name === 'vnsh_share_file') {
       return await handleShareFile(args);
+    } else if (name === 'vnsh_workspace_create') {
+      return await handleWorkspaceCreate(args);
+    } else if (name === 'vnsh_workspace_read') {
+      return await handleWorkspaceRead(args);
+    } else if (name === 'vnsh_workspace_update') {
+      return await handleWorkspaceUpdate(args);
+    } else if (name === 'vnsh_workspace_open') {
+      return await handleWorkspaceOpen(args);
     } else {
       throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);
     }
@@ -539,6 +643,225 @@ export async function handleShareFile(args: unknown) {
       fileName,
       originalSize: stat.size,
     },
+  };
+}
+
+/**
+ * Handle vnsh_workspace_create tool call
+ * @internal Exported for testing
+ */
+export async function handleWorkspaceCreate(args: unknown) {
+  const { content, host: hostOverride } = WorkspaceCreateSchema.parse(args);
+  const host = hostOverride || DEFAULT_HOST;
+
+  const secret = generateRootSecret();
+  const { key, writeHash } = deriveWorkspaceKeys(secret);
+  const encrypted = encryptWorkspace(content, key);
+
+  const response = await fetch(`${host}/api/workspace`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'X-Vnsh-Write-Hash': writeHash,
+      ...CLIENT_HEADER,
+    },
+    body: new Uint8Array(encrypted),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Create failed: HTTP ${response.status} - ${await response.text()}`);
+  }
+
+  const data = (await response.json()) as { id: string; version: number; expires: string };
+  const url = buildWorkspaceUrl(host, data.id, secret);
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          `Workspace created at version ${data.version}.\n\n${url}\n\n` +
+          `Expires ${data.expires} (24h after the last write — each update renews it).\n` +
+          `Hand this URL to any other agent or session: they can read it with ` +
+          `vnsh_workspace_read and write to it with vnsh_workspace_update. ` +
+          `The key lives in the #w= fragment and never reaches the server.`,
+      },
+    ],
+    metadata: { url, workspaceId: data.id, version: data.version, expires: data.expires },
+  };
+}
+
+// Fetch and decrypt a workspace. Shared by read/update/open.
+async function fetchWorkspace(url: string) {
+  const { host, id, secret } = parseWorkspaceUrl(url);
+  const { key, writeToken } = deriveWorkspaceKeys(secret);
+
+  const response = await fetch(`${host}/api/workspace/${id}`, {
+    headers: { Accept: 'application/octet-stream', ...CLIENT_HEADER },
+  });
+
+  if (response.status === 404) {
+    throw new Error('Workspace not found — it may have expired (24h after the last write).');
+  }
+  if (response.status === 410) {
+    throw new Error('Workspace has expired.');
+  }
+  if (!response.ok) {
+    throw new Error(`Read failed: HTTP ${response.status} - ${await response.text()}`);
+  }
+
+  const payload = Buffer.from(await response.arrayBuffer());
+  if (payload.length > MAX_CONTENT_SIZE) {
+    throw new Error(`Workspace is too large (${payload.length} bytes)`);
+  }
+
+  const version = parseInt((response.headers.get('ETag') || '"1"').replace(/"/g, ''), 10);
+
+  let plaintext: Buffer;
+  try {
+    plaintext = decryptWorkspace(payload, key);
+  } catch {
+    // GCM tag failure means the key is wrong or the bytes were altered — the
+    // integrity guarantee CBC could not give us.
+    throw new Error(
+      'Decryption failed: the key in the URL does not match, or the content was tampered with.',
+    );
+  }
+
+  return { host, id, version, writeToken, key, secret, plaintext };
+}
+
+/**
+ * Handle vnsh_workspace_read tool call
+ * @internal Exported for testing
+ */
+export async function handleWorkspaceRead(args: unknown) {
+  const { url } = WorkspaceUrlSchema.parse(args);
+  const { id, version, plaintext } = await fetchWorkspace(url);
+  const text = plaintext.toString('utf-8');
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          `Workspace ${id} — version ${version}.\n` +
+          `To modify it, call vnsh_workspace_update with base_version: ${version}.\n\n` +
+          text,
+      },
+    ],
+    metadata: { workspaceId: id, version, size: plaintext.length },
+  };
+}
+
+/**
+ * Handle vnsh_workspace_update tool call
+ * @internal Exported for testing
+ */
+export async function handleWorkspaceUpdate(args: unknown) {
+  const { url, content, base_version } = WorkspaceUpdateSchema.parse(args);
+  const { host, id, secret } = parseWorkspaceUrl(url);
+  const { key, writeToken } = deriveWorkspaceKeys(secret);
+
+  // Without an explicit base, read the latest so we write against something real.
+  let version = base_version;
+  if (version === undefined) {
+    version = (await fetchWorkspace(url)).version;
+  }
+
+  const encrypted = encryptWorkspace(content, key);
+  const response = await fetch(`${host}/api/workspace/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'X-Vnsh-Write': writeToken,
+      'If-Match': `"${version}"`,
+      ...CLIENT_HEADER,
+    },
+    body: new Uint8Array(encrypted),
+  });
+
+  if (response.status === 412) {
+    // Someone wrote first. Hand back their content in the same turn so the agent
+    // can merge and retry immediately instead of guessing what changed.
+    const current = await fetchWorkspace(url);
+    return {
+      content: [
+        {
+          type: 'text',
+          text:
+            `Write rejected: the workspace moved to version ${current.version} while you were ` +
+            `working from version ${version}. Your content was NOT saved.\n\n` +
+            `Below is the current content. Merge your intended change into it, then call ` +
+            `vnsh_workspace_update again with base_version: ${current.version}.\n\n` +
+            `--- current version ${current.version} ---\n${current.plaintext.toString('utf-8')}`,
+        },
+      ],
+      isError: true,
+      metadata: { workspaceId: id, conflict: true, currentVersion: current.version },
+    };
+  }
+
+  if (response.status === 403) {
+    throw new Error('This URL does not grant write access to that workspace.');
+  }
+  if (!response.ok) {
+    throw new Error(`Update failed: HTTP ${response.status} - ${await response.text()}`);
+  }
+
+  const data = (await response.json()) as { version: number; expires: string };
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          `Workspace updated to version ${data.version}. The URL is unchanged.\n` +
+          `Expires ${data.expires}.`,
+      },
+    ],
+    metadata: { workspaceId: id, version: data.version, expires: data.expires },
+  };
+}
+
+/**
+ * Handle vnsh_workspace_open tool call
+ * @internal Exported for testing
+ */
+export async function handleWorkspaceOpen(args: unknown) {
+  const { url } = WorkspaceUrlSchema.parse(args);
+  const { id, version, plaintext } = await fetchWorkspace(url);
+
+  const text = plaintext.toString('utf-8');
+  const looksHtml = /^\s*(<!doctype html|<html|<head|<body|<div|<style|<h1)/i.test(text);
+  const ext = looksHtml ? 'html' : 'txt';
+  const filePath = path.join(os.tmpdir(), `vnsh-workspace-${id}-v${version}.${ext}`);
+  fs.writeFileSync(filePath, plaintext, { mode: 0o600 });
+
+  // Rendering from file:// keeps user content off every vnsh origin, so a
+  // workspace can never script the site or read another workspace.
+  const opener =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+  let opened = true;
+  try {
+    const { spawn } = await import('child_process');
+    spawn(opener, [filePath], { detached: true, stdio: 'ignore', shell: process.platform === 'win32' }).unref();
+  } catch {
+    opened = false;
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          (opened
+            ? `Opened workspace ${id} (version ${version}) in the browser.\n`
+            : `Could not launch a browser automatically.\n`) +
+          `File: ${filePath}\n` +
+          `Rendered locally from file:// — the decrypted content never leaves this machine.`,
+      },
+    ],
+    metadata: { workspaceId: id, version, filePath, opened },
   };
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -699,9 +699,19 @@ export default {
     let checked = 0;
     let cursor: string | undefined;
 
-    // R2 list is paginated (max 1000 per call)
+    // R2 list is paginated (max 1000 per call).
+    // include:['customMetadata'] is REQUIRED — without it R2 returns an empty
+    // customMetadata object, expiresAt reads as undefined, and every object falls
+    // through to the 8-day legacy branch below instead of its real 24h expiry.
     do {
-      const listed = await env.VNSH_STORE.list({ limit: 1000, cursor });
+      const listed = await env.VNSH_STORE.list({
+        limit: 1000,
+        cursor,
+        include: ['customMetadata'],
+        // The runtime supports `include`, but the pinned @cloudflare/workers-types
+        // (4.20241230) predates it being added to R2ListOptions. Verified against
+        // workerd: without the flag customMetadata comes back as {}.
+      } as R2ListOptions & { include: ('customMetadata' | 'httpMetadata')[] });
 
       for (const obj of listed.objects) {
         checked++;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -66,8 +66,12 @@ function isValidBlobId(id: string): boolean {
 // CORS headers for cross-origin access
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, HEAD, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, X-Vnsh-Client',
+  'Access-Control-Allow-Methods': 'GET, HEAD, POST, PUT, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, If-Match, X-Vnsh-Client, X-Vnsh-Write, X-Vnsh-Write-Hash',
+  // Browser clients need to read the version off a workspace GET to build the
+  // If-Match on the next write; without this the fetch() response hides it.
+  'Access-Control-Expose-Headers': 'ETag, X-Vnsh-Expires, X-Opaque-Expires',
   'Access-Control-Max-Age': '86400',
 };
 
@@ -218,13 +222,25 @@ function getClientSource(request: Request): string {
 // Usage analytics via Workers Analytics Engine. writeDataPoint is non-blocking and
 // fire-and-forget (no await / waitUntil needed) with a high write allowance, so it
 // replaces the racy read-modify-write KV counters. Schema:
-//   blob1 = event type ('upload' | 'read'), blob2 = client source, double1 = count,
-//   index1 = event type (sampling key). timestamp is added automatically.
-function trackEvent(env: Env, event: 'upload' | 'read', source: string): void {
+//   blob1 = event type, blob2 = client source, blob3 = workspace id (workspace
+//   events only), double1 = count, index1 = event type (sampling key).
+//   timestamp is added automatically.
+//
+// blob3 exists to answer the one question v2 is built to test: has a single
+// workspace been written by more than one distinct source? Without it we cannot
+// distinguish "three agents collaborated" from "one agent wrote three times".
+type TrackedEvent =
+  | 'upload'
+  | 'read'
+  | 'workspace_create'
+  | 'workspace_read'
+  | 'workspace_update';
+
+function trackEvent(env: Env, event: TrackedEvent, source: string, workspaceId?: string): void {
   if (!env.VNSH_ANALYTICS) return; // Analytics Engine not bound yet — no-op.
   try {
     env.VNSH_ANALYTICS.writeDataPoint({
-      blobs: [event, source],
+      blobs: workspaceId ? [event, source, workspaceId] : [event, source],
       doubles: [1],
       indexes: [event],
     });
@@ -424,6 +440,294 @@ async function handleBlob(id: string, request: Request, env: Env, ctx: Execution
   });
 }
 
+// ---------------------------------------------------------------------------
+// Workspaces (v2) — mutable, versioned, host-blind.
+//
+// A workspace is a stable ID whose content can be replaced by anyone holding the
+// write token. The server stays blind: it only ever sees ciphertext plus
+// H = SHA-256(W), a one-way derivation of the write token. It cannot recover the
+// root secret, cannot decrypt, and cannot forge a write.
+//
+// Phase 0 stores only the latest version at `w/{id}`; the version counter lives
+// in customMetadata so optimistic concurrency works today and per-version history
+// can be added later without changing the URL format.
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_PREFIX = 'w/';
+
+function isValidWorkspaceId(id: string): boolean {
+  return /^[0-9A-Za-z]{12}$/.test(id);
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// Length-independent comparison so a mismatching hash can't be recovered byte by
+// byte from response timing.
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+// A 64-char hex string — the shape of both H and W.
+function isValidWriteHash(value: string | null): value is string {
+  return !!value && /^[a-f0-9]{64}$/.test(value);
+}
+
+function workspaceExpiry(): { expiresAt: number; iso: string } {
+  const expiresAt = Date.now() + DEFAULT_TTL_HOURS * 60 * 60 * 1000;
+  return { expiresAt, iso: new Date(expiresAt).toISOString() };
+}
+
+// POST /api/workspace — create a workspace and return its ID.
+async function handleWorkspaceCreate(request: Request, env: Env): Promise<Response> {
+  const writeHash = request.headers.get('X-Vnsh-Write-Hash');
+  if (!isValidWriteHash(writeHash)) {
+    return errorResponse(
+      'INVALID_WRITE_HASH',
+      'X-Vnsh-Write-Hash must be the SHA-256 of the write token, as 64 hex chars',
+      400,
+    );
+  }
+
+  const contentLength = request.headers.get('Content-Length');
+  if (contentLength && parseInt(contentLength, 10) > MAX_BLOB_SIZE) {
+    return errorResponse(
+      'PAYLOAD_TOO_LARGE',
+      `Maximum workspace size is ${MAX_BLOB_SIZE / 1024 / 1024}MB`,
+      413,
+    );
+  }
+
+  const body = request.body;
+  if (!body) {
+    return errorResponse('EMPTY_BODY', 'Request body is required', 400);
+  }
+
+  let id = generateShortId();
+  for (let attempts = 0; attempts < 5; attempts++) {
+    if (!(await env.VNSH_STORE.head(WORKSPACE_PREFIX + id))) break;
+    id = generateShortId();
+  }
+
+  const { iso } = workspaceExpiry();
+  try {
+    await env.VNSH_STORE.put(WORKSPACE_PREFIX + id, body, {
+      customMetadata: {
+        writeHash,
+        version: '1',
+        createdAt: new Date().toISOString(),
+        expiresAt: iso,
+      },
+    });
+  } catch (err) {
+    console.error('Failed to create workspace:', err);
+    return errorResponse('STORAGE_ERROR', 'Failed to create workspace', 500);
+  }
+
+  trackEvent(env, 'workspace_create', getClientSource(request), id);
+
+  return new Response(JSON.stringify({ id, version: 1, expires: iso }), {
+    status: 201,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+  });
+}
+
+// GET /api/workspace/:id — return the latest ciphertext. Dumb pipe, as with blobs.
+async function handleWorkspaceGet(id: string, request: Request, env: Env): Promise<Response> {
+  const key = WORKSPACE_PREFIX + id;
+  const head = await env.VNSH_STORE.head(key);
+  if (!head) {
+    return errorResponse('NOT_FOUND', 'Workspace not found or expired', 404, request);
+  }
+
+  const md = head.customMetadata || {};
+  const expiresAtMs = md.expiresAt ? new Date(md.expiresAt).getTime() : NaN;
+  if (!isNaN(expiresAtMs) && Date.now() > expiresAtMs) {
+    await env.VNSH_STORE.delete(key);
+    return errorResponse('EXPIRED', 'Workspace has expired', 410, request);
+  }
+
+  const object = await env.VNSH_STORE.get(key);
+  if (!object) {
+    // Rare race: deleted between head and get.
+    return errorResponse('NOT_FOUND', 'Workspace not found or expired', 404, request);
+  }
+
+  trackEvent(env, 'workspace_read', getClientSource(request), id);
+
+  return new Response(object.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': String(object.size),
+      'Cache-Control': 'private, no-store, no-cache',
+      'X-Content-Type-Options': 'nosniff',
+      // The version IS the ETag — one concept, not two.
+      ETag: `"${md.version || '1'}"`,
+      ...(md.expiresAt ? { 'X-Vnsh-Expires': md.expiresAt } : {}),
+      ...corsHeaders,
+    },
+  });
+}
+
+// PUT /api/workspace/:id — replace content, bump version, renew TTL.
+async function handleWorkspacePut(id: string, request: Request, env: Env): Promise<Response> {
+  const key = WORKSPACE_PREFIX + id;
+
+  const writeToken = request.headers.get('X-Vnsh-Write');
+  if (!isValidWriteHash(writeToken)) {
+    return errorResponse(
+      'INVALID_WRITE_TOKEN',
+      'X-Vnsh-Write must be the write token, as 64 hex chars',
+      401,
+    );
+  }
+
+  const ifMatch = request.headers.get('If-Match');
+  if (!ifMatch) {
+    // Refusing an unconditional write is what stops one agent silently clobbering
+    // another's update.
+    return errorResponse(
+      'PRECONDITION_REQUIRED',
+      'If-Match with the current version is required',
+      428,
+    );
+  }
+
+  const contentLength = request.headers.get('Content-Length');
+  if (contentLength && parseInt(contentLength, 10) > MAX_BLOB_SIZE) {
+    return errorResponse(
+      'PAYLOAD_TOO_LARGE',
+      `Maximum workspace size is ${MAX_BLOB_SIZE / 1024 / 1024}MB`,
+      413,
+    );
+  }
+
+  const head = await env.VNSH_STORE.head(key);
+  if (!head) {
+    return errorResponse('NOT_FOUND', 'Workspace not found or expired', 404, request);
+  }
+
+  const md = head.customMetadata || {};
+  const expiresAtMs = md.expiresAt ? new Date(md.expiresAt).getTime() : NaN;
+  if (!isNaN(expiresAtMs) && Date.now() > expiresAtMs) {
+    await env.VNSH_STORE.delete(key);
+    return errorResponse('EXPIRED', 'Workspace has expired', 410, request);
+  }
+
+  const expectedHash = md.writeHash || '';
+  const presentedHash = await sha256Hex(writeToken);
+  if (!timingSafeEqual(presentedHash, expectedHash)) {
+    return errorResponse('FORBIDDEN', 'Invalid write token', 403, request);
+  }
+
+  const currentVersion = md.version || '1';
+  if (ifMatch.replace(/"/g, '') !== currentVersion) {
+    return errorResponse(
+      'VERSION_CONFLICT',
+      `Workspace is at version ${currentVersion}; re-read it, merge your change, then retry`,
+      412,
+      request,
+    );
+  }
+
+  const body = request.body;
+  if (!body) {
+    return errorResponse('EMPTY_BODY', 'Request body is required', 400);
+  }
+
+  const nextVersion = String(parseInt(currentVersion, 10) + 1);
+  const { iso } = workspaceExpiry();
+
+  try {
+    // etagMatches makes this a genuine compare-and-swap: two agents that both read
+    // version 7 cannot both land a version 8.
+    const written = await env.VNSH_STORE.put(key, body, {
+      onlyIf: { etagMatches: head.etag },
+      customMetadata: {
+        writeHash: expectedHash,
+        version: nextVersion,
+        createdAt: md.createdAt || new Date().toISOString(),
+        expiresAt: iso,
+      },
+    });
+
+    if (!written) {
+      return errorResponse(
+        'VERSION_CONFLICT',
+        'Workspace changed during this write; re-read it, merge your change, then retry',
+        412,
+        request,
+      );
+    }
+  } catch (err) {
+    console.error('Failed to update workspace:', err);
+    return errorResponse('STORAGE_ERROR', 'Failed to update workspace', 500);
+  }
+
+  trackEvent(env, 'workspace_update', getClientSource(request), id);
+
+  return new Response(
+    JSON.stringify({ id, version: parseInt(nextVersion, 10), expires: iso }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ETag: `"${nextVersion}"`, ...corsHeaders },
+    },
+  );
+}
+
+// Landing page for /w/:id. Static and content-free by design — the workspace key
+// is in the fragment, and nothing here should ever touch it.
+const WORKSPACE_PAGE = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>vnsh workspace</title>
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
+<style>
+  body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+    background:#0d1117;color:#c9d1d9;font:15px/1.7 -apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;padding:24px}
+  main{max-width:34rem}
+  h1{font-size:1.25rem;margin:0 0 .6em;color:#e6edf3;font-weight:600}
+  p{margin:0 0 1em;color:#9da7b3}
+  code{font-family:ui-monospace,'SF Mono',Menlo,monospace;font-size:.86em;background:#161b22;
+    border:1px solid #21262d;border-radius:5px;padding:.15em .45em;color:#e6edf3;display:inline-block}
+  pre{background:#161b22;border:1px solid #21262d;border-radius:8px;padding:14px 16px;overflow-x:auto;
+    font-family:ui-monospace,'SF Mono',Menlo,monospace;font-size:.82rem;color:#adbac7;margin:0 0 1em}
+  .k{color:#7ee787}
+  small{color:#6e7681;font-size:.82rem}
+</style>
+</head>
+<body>
+<main>
+  <h1>This is a vnsh workspace</h1>
+  <p>
+    A shared, encrypted document that several AI agents can read and write through
+    one link. The decryption key is in this URL's <code>#</code> fragment, which
+    browsers never send to the server &mdash; so vnsh cannot read this workspace.
+  </p>
+  <p>Open it with an agent that has the vnsh MCP server, or from a terminal:</p>
+  <pre><span class="k">npx vnsh workspace read</span> "&lt;this full URL&gt;"</pre>
+  <p>
+    <small>
+      Content is not rendered on this page on purpose: running a workspace's own HTML
+      here would let it read the key out of the address bar. Agents render it locally instead.
+      Workspaces expire 24 hours after the last write.
+    </small>
+  </p>
+</main>
+</body>
+</html>`;
+
 // Main request handler
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -486,6 +790,47 @@ export default {
         return handleDrop(request, env, ctx);
       }
       return errorResponse('METHOD_NOT_ALLOWED', 'Use POST to upload', 405);
+    }
+
+    // Route: POST /api/workspace - create a mutable workspace
+    if (path === '/api/workspace') {
+      if (request.method === 'POST') {
+        const ip = getClientIp(request);
+        if (!(await checkRateLimit(env.UPLOAD_LIMITER, ip))) return rateLimitResponse();
+        return handleWorkspaceCreate(request, env);
+      }
+      return errorResponse('METHOD_NOT_ALLOWED', 'Use POST to create a workspace', 405);
+    }
+
+    // Route: GET/PUT /api/workspace/:id
+    const workspaceMatch = path.match(/^\/api\/workspace\/([a-zA-Z0-9]+)$/);
+    if (workspaceMatch && isValidWorkspaceId(workspaceMatch[1])) {
+      const ip = getClientIp(request);
+      if (request.method === 'GET') {
+        if (!(await checkRateLimit(env.READ_LIMITER, ip))) return rateLimitResponse();
+        return handleWorkspaceGet(workspaceMatch[1], request, env);
+      }
+      if (request.method === 'PUT') {
+        if (!(await checkRateLimit(env.UPLOAD_LIMITER, ip))) return rateLimitResponse();
+        return handleWorkspacePut(workspaceMatch[1], request, env);
+      }
+      return errorResponse('METHOD_NOT_ALLOWED', 'Use GET or PUT', 405);
+    }
+
+    // Route: GET /w/:id - workspace landing page.
+    // Phase 0 deliberately does NOT render workspace content here: doing so would
+    // run user-supplied HTML on the vnsh.dev origin, where it could read the key
+    // out of location.hash. Agents open workspaces locally from file:// instead.
+    const workspacePageMatch = path.match(/^\/w\/([a-zA-Z0-9]+)$/);
+    if (request.method === 'GET' && workspacePageMatch && isValidWorkspaceId(workspacePageMatch[1])) {
+      return new Response(WORKSPACE_PAGE, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control': 'no-cache',
+          'Referrer-Policy': 'no-referrer',
+        },
+      });
     }
 
     // Route: GET /api/blob/:id
@@ -1102,9 +1447,9 @@ vn() {
     _vn_cleanup() { rm -f "\$_VN_TMP" 2>/dev/null; }
     trap _vn_cleanup EXIT INT TERM
     if [ -t 2 ]; then
-      curl -f --progress-bar "\$_VN_HOST/api/blob/\$_VN_ID" 2>&2 | openssl enc -d -aes-256-cbc -K "\$_VN_KEY" -iv "\$_VN_IV" 2>/dev/null > "\$_VN_TMP"
+      curl -f --progress-bar -H "X-Vnsh-Client: pipe/1.0" "\$_VN_HOST/api/blob/\$_VN_ID" 2>&2 | openssl enc -d -aes-256-cbc -K "\$_VN_KEY" -iv "\$_VN_IV" 2>/dev/null > "\$_VN_TMP"
     else
-      curl -sf "\$_VN_HOST/api/blob/\$_VN_ID" | openssl enc -d -aes-256-cbc -K "\$_VN_KEY" -iv "\$_VN_IV" 2>/dev/null > "\$_VN_TMP"
+      curl -sf -H "X-Vnsh-Client: pipe/1.0" "\$_VN_HOST/api/blob/\$_VN_ID" | openssl enc -d -aes-256-cbc -K "\$_VN_KEY" -iv "\$_VN_IV" 2>/dev/null > "\$_VN_TMP"
     fi
     _VN_RET=\$?
     if [ \$_VN_RET -ne 0 ] || [ ! -s "\$_VN_TMP" ]; then
@@ -4087,7 +4432,7 @@ const APP_HTML = `<!DOCTYPE html>
     async function fetchAndDecrypt(id, keyHex, ivHex) {
       try {
         document.getElementById('step-fetch').className = 'step active';
-        const res = await fetch('/api/blob/' + id);
+        const res = await fetch('/api/blob/' + id, { headers: { 'X-Vnsh-Client': 'web/1.0' } });
         if (res.status === 404) throw new Error('Blob not found or expired.');
         if (res.status === 410) throw new Error('Blob has expired.');
         if (!res.ok) throw new Error('Fetch failed: ' + res.status);

--- a/worker/test/api.test.ts
+++ b/worker/test/api.test.ts
@@ -268,7 +268,9 @@ describe('vnsh API', () => {
       expect(html).toContain('ai-instructions');
       expect(html).toContain('AI Agent');
       expect(html).toContain('curl -sL vnsh.dev/claude | sh');
-      expect(html).toContain('vnsh_read');
+      // The banner points at the zero-install path so an agent with only a shell
+      // can act on it; it no longer names the MCP tool, which requires setup first.
+      expect(html).toContain('npx vnsh read');
     });
 
     it('does not redirect (would break hash fragment)', async () => {
@@ -368,6 +370,32 @@ describe('vnsh API', () => {
       expect(response.status).toBe(404);
       const body = await response.json() as { error: string };
       expect(body.error).toBe('NOT_FOUND');
+    });
+  });
+
+  // Regression: list() without include:['customMetadata'] returns an empty
+  // customMetadata object, so expiresAt read as undefined and every object fell
+  // through to the 8-day legacy branch — blobs lived ~8 days instead of 24h.
+  describe('cleanup cron', () => {
+    it('sees customMetadata when listing, so expired objects are collected', async () => {
+      const key = 'cccccccccccc';
+      await env.VNSH_STORE.put(key, 'expired-bytes', {
+        customMetadata: { expiresAt: new Date(Date.now() - 1000).toISOString() },
+      });
+
+      const listed = await env.VNSH_STORE.list({
+        limit: 1000,
+        include: ['customMetadata'],
+      } as R2ListOptions & { include: ('customMetadata' | 'httpMetadata')[] });
+
+      const found = listed.objects.find((o) => o.key === key);
+      expect(found?.customMetadata?.expiresAt).toBeDefined();
+
+      const ctx = createExecutionContext();
+      await worker.scheduled!({} as ScheduledEvent, env as Env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(await env.VNSH_STORE.head(key)).toBeNull();
     });
   });
 });

--- a/worker/test/workspace.test.ts
+++ b/worker/test/workspace.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import worker from '../src/index';
+
+type Env = { VNSH_STORE: R2Bucket };
+
+// The write token is any 64 hex chars; the server only ever stores its SHA-256.
+const WRITE_TOKEN = 'a'.repeat(64);
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function call(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const response = await worker.fetch(request, env as Env, ctx);
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+async function createWorkspace(body = 'ciphertext-v1', token = WRITE_TOKEN) {
+  const response = await call(
+    new Request('http://localhost/api/workspace', {
+      method: 'POST',
+      headers: { 'X-Vnsh-Write-Hash': await sha256Hex(token) },
+      body,
+    }),
+  );
+  const json = (await response.json()) as { id: string; version: number; expires: string };
+  return { response, ...json };
+}
+
+function put(id: string, body: string, ifMatch: string, token = WRITE_TOKEN) {
+  return call(
+    new Request(`http://localhost/api/workspace/${id}`, {
+      method: 'PUT',
+      headers: { 'X-Vnsh-Write': token, 'If-Match': ifMatch },
+      body,
+    }),
+  );
+}
+
+describe('Workspaces', () => {
+  describe('POST /api/workspace', () => {
+    it('creates a workspace at version 1', async () => {
+      const { response, id, version, expires } = await createWorkspace();
+
+      expect(response.status).toBe(201);
+      expect(id).toMatch(/^[0-9A-Za-z]{12}$/);
+      expect(version).toBe(1);
+      expect(new Date(expires).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('rejects a missing write hash', async () => {
+      const response = await call(
+        new Request('http://localhost/api/workspace', { method: 'POST', body: 'x' }),
+      );
+      expect(response.status).toBe(400);
+      expect((await response.json() as { error: string }).error).toBe('INVALID_WRITE_HASH');
+    });
+
+    it('rejects a malformed write hash', async () => {
+      const response = await call(
+        new Request('http://localhost/api/workspace', {
+          method: 'POST',
+          headers: { 'X-Vnsh-Write-Hash': 'not-a-hash' },
+          body: 'x',
+        }),
+      );
+      expect(response.status).toBe(400);
+      await response.arrayBuffer();
+    });
+
+    it('rejects GET', async () => {
+      const response = await call(new Request('http://localhost/api/workspace'));
+      expect(response.status).toBe(405);
+      await response.arrayBuffer();
+    });
+  });
+
+  describe('GET /api/workspace/:id', () => {
+    it('returns the ciphertext with the version as ETag', async () => {
+      const { id } = await createWorkspace('secret-bytes');
+
+      const response = await call(new Request(`http://localhost/api/workspace/${id}`));
+      expect(response.status).toBe(200);
+      expect(response.headers.get('ETag')).toBe('"1"');
+      expect(await response.text()).toBe('secret-bytes');
+    });
+
+    it('exposes ETag to cross-origin callers', async () => {
+      const { id } = await createWorkspace();
+      const response = await call(new Request(`http://localhost/api/workspace/${id}`));
+      expect(response.headers.get('Access-Control-Expose-Headers')).toContain('ETag');
+      await response.arrayBuffer(); // drain: an unconsumed R2 body leaks the storage handle
+    });
+
+    it('returns 404 for an unknown workspace', async () => {
+      const response = await call(new Request('http://localhost/api/workspace/aaaaaaaaaaaa'));
+      expect(response.status).toBe(404);
+      await response.arrayBuffer();
+    });
+  });
+
+  describe('PUT /api/workspace/:id', () => {
+    it('bumps the version and returns the new content on read', async () => {
+      const { id } = await createWorkspace('v1-bytes');
+
+      const response = await put(id, 'v2-bytes', '"1"');
+      expect(response.status).toBe(200);
+      expect((await response.json() as { version: number }).version).toBe(2);
+
+      const read = await call(new Request(`http://localhost/api/workspace/${id}`));
+      expect(read.headers.get('ETag')).toBe('"2"');
+      expect(await read.text()).toBe('v2-bytes');
+    });
+
+    it('accepts an unquoted If-Match', async () => {
+      const { id } = await createWorkspace();
+      const response = await put(id, 'next', '1');
+      expect(response.status).toBe(200);
+      await response.arrayBuffer();
+    });
+
+    it('rejects a wrong write token with 403', async () => {
+      const { id } = await createWorkspace();
+      const response = await put(id, 'evil', '"1"', 'b'.repeat(64));
+      expect(response.status).toBe(403);
+      await response.arrayBuffer();
+
+      // Content must be untouched.
+      const read = await call(new Request(`http://localhost/api/workspace/${id}`));
+      expect(await read.text()).toBe('ciphertext-v1');
+    });
+
+    it('rejects a missing write token with 401', async () => {
+      const { id } = await createWorkspace();
+      const response = await call(
+        new Request(`http://localhost/api/workspace/${id}`, {
+          method: 'PUT',
+          headers: { 'If-Match': '"1"' },
+          body: 'x',
+        }),
+      );
+      expect(response.status).toBe(401);
+      await response.arrayBuffer();
+    });
+
+    it('refuses an unconditional write with 428', async () => {
+      const { id } = await createWorkspace();
+      const response = await call(
+        new Request(`http://localhost/api/workspace/${id}`, {
+          method: 'PUT',
+          headers: { 'X-Vnsh-Write': WRITE_TOKEN },
+          body: 'x',
+        }),
+      );
+      expect(response.status).toBe(428);
+      await response.arrayBuffer();
+    });
+
+    it('rejects a stale If-Match with 412 and names the current version', async () => {
+      const { id } = await createWorkspace();
+      await put(id, 'v2', '"1"');
+
+      const response = await put(id, 'v3-from-stale-reader', '"1"');
+      expect(response.status).toBe(412);
+      expect((await response.json() as { message: string }).message).toContain('version 2');
+
+      // The stale write must not have landed.
+      const read = await call(new Request(`http://localhost/api/workspace/${id}`));
+      expect(await read.text()).toBe('v2');
+    });
+
+    it('returns 404 when the workspace does not exist', async () => {
+      const response = await put('bbbbbbbbbbbb', 'x', '"1"');
+      expect(response.status).toBe(404);
+      await response.arrayBuffer();
+    });
+
+    it('renews the TTL on every write', async () => {
+      const { id, expires } = await createWorkspace();
+      const first = new Date(expires).getTime();
+
+      const response = await put(id, 'v2', '"1"');
+      const renewed = new Date((await response.json() as { expires: string }).expires).getTime();
+
+      expect(renewed).toBeGreaterThanOrEqual(first);
+    });
+  });
+
+  describe('expiry', () => {
+    it('returns 410 and deletes once past expiresAt', async () => {
+      const { id } = await createWorkspace();
+
+      // Backdate the expiry in place.
+      const key = `w/${id}`;
+      const existing = await env.VNSH_STORE.get(key);
+      const body = await existing!.arrayBuffer();
+      await env.VNSH_STORE.put(key, body, {
+        customMetadata: {
+          ...existing!.customMetadata,
+          expiresAt: new Date(Date.now() - 1000).toISOString(),
+        },
+      });
+
+      const response = await call(new Request(`http://localhost/api/workspace/${id}`));
+      expect(response.status).toBe(410);
+      await response.arrayBuffer();
+      expect(await env.VNSH_STORE.head(key)).toBeNull();
+    });
+  });
+});
+
+describe('GET /w/:id landing page', () => {
+  it('serves a page instead of 404 so the URL is not a dead end', async () => {
+    const response = await call(new Request('http://localhost/w/aBcDeFgHiJkL'));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('vnsh workspace');
+    // Phase 0 must not render workspace content on the vnsh origin — user HTML
+    // there could read the key out of location.hash.
+    expect(html).toContain("default-src 'none'");
+    expect(html).not.toContain('<script');
+  });
+});


### PR DESCRIPTION
Two commits: a standalone fix for a live expiry bug, then Phase 0 of the v2 workspace feature.

## 1. Cleanup cron never saw expiry metadata

R2's `list()` omits `customMetadata` unless `include:['customMetadata']` is passed. Without it `obj.customMetadata?.expiresAt` was always `undefined`, so every object fell through to the legacy "no expiry recorded" branch and survived **8 days instead of 24 hours**.

Production had 460 objects — almost exactly 8 days of uploads at the current rate.

The read path was unaffected (expiry is checked via `head()`, expired reads return 410), so no one could read expired content. But ciphertext sat in R2 a week longer than advertised, which contradicts the core "vaporizes in 24 hours" claim. Verified against workerd before and after.

This commit stands alone and passes on its own (40/40).

## 2. Portable workspaces

A mutable, versioned, host-blind document so agents from different vendors can collaborate through one URL, instead of the user copy-pasting context between Claude Code, Cursor, OpenHands and friends.

```
POST /api/workspace      create; stores H = SHA-256(W)
GET  /api/workspace/:id  ciphertext; the version IS the ETag
PUT  /api/workspace/:id  verify W, check If-Match, bump version, renew TTL
GET  /w/:id              static landing page
```

**Key derivation** — the server authorizes writes without being able to decrypt:

```
S = random(32)                 root secret, lives only in the #w= fragment
K = HKDF(S, "vnsh/enc/v2")     content key
W = HKDF(S, "vnsh/write/v2")   write token
H = SHA-256(W)                 the only derived value the server stores
```

**AES-256-GCM**, not the CBC used by v1 blobs. Mutable content needs integrity: without an auth tag anyone able to rewrite storage — including the host — could flip ciphertext bits undetectably, which hollows out the host-blind claim. The nonce is random per write and prepended, so reuse (which under GCM leaks the auth key, not just plaintext) is impossible with no version bookkeeping on the client.

**Concurrency** uses R2 conditional writes (`onlyIf.etagMatches`) on top of the version check, so two agents that both read version 7 cannot both land a version 8. An unconditional `PUT` is refused with 428 rather than silently clobbering.

**MCP** gains `vnsh_workspace_create / read / update / open`. Descriptions are framed around handing work to another agent rather than around output being too long to print — the old "use when output exceeds ~50 lines" framing only fires on overflow and would never produce collaboration. On a 412 the update tool returns the current content in the same turn so the model can merge and retry instead of guessing what changed.

`vnsh_workspace_open` decrypts to a local temp file (0600) and opens `file://`. Rendering user HTML on a vnsh origin would let it read the key out of `location.hash`, so `/w/:id` deliberately renders nothing — which also defers all sandbox-domain work.

**Analytics**: the viewer and `vn read` now send `X-Vnsh-Client`, and workspace events carry the workspace id. Previously all 495 reads were attributed to `unknown`, making it impossible to tell whether several agents touched one workspace or one agent touched it repeatedly — the single measurement this phase exists to produce.

## Scope

Deliberately **not** included, pending signal from real use: read-only links, version history, an append channel, server-side rendering, and any packaging (microagent / plugin / hook).

v1 `/v/` blobs, their CBC encryption and their URL format are untouched.

## Verification

- worker 57/57, mcp 137/137, extension 48/48; both packages typecheck
- Commit 1 verified to pass standalone
- Cross-agent round trip against **production R2**: agent A creates → agent B recovers everything from the URL alone → B writes v2 → A reads B's work; stale writer 412, wrong token 403, unconditional 428, stored bytes contain no plaintext, tampered ciphertext rejected by GCM
- Confirmed `onlyIf.etagMatches` behaves on real R2, which miniflare could not prove
- Production regression: v1 drop/blob round trip intact, 7 key pages 200

Note: this is already deployed (version `9eb6372b`) — it was verified in production before this PR was opened, so main and production are briefly out of step until merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)