### PR TITLE
Render markdown in the workspace viewer

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1320,6 +1320,201 @@ Protocol, key schedule and setup: https://vnsh.dev/llms.txt
     '})();'
   ].join('');
 
+  // Kept in step with the viewer's own palette so rendered content reads as part
+  // of the page rather than something bolted into a frame. Inline only: the
+  // injected policy allows no stylesheet, font, or image from the network.
+  var MD_CSS = [
+    ':root{--bg:#0d1117;--panel:#161b22;--line:#21262d;--ink:#e6edf3;',
+    '--ink-2:#9da7b3;--ink-3:#6e7681;--accent:#d29922}',
+    '*{box-sizing:border-box}',
+    'body{margin:0;padding:22px 24px 56px;background:var(--bg);color:var(--ink);',
+    "font:15px/1.7 -apple-system,BlinkMacSystemFont,'Segoe UI','PingFang SC',system-ui,sans-serif;",
+    'overflow-wrap:break-word}',
+    'h1,h2,h3,h4,h5,h6{line-height:1.3;margin:1.7em 0 .6em;font-weight:600}',
+    'h1{font-size:1.7em;letter-spacing:-.02em}h2{font-size:1.34em;letter-spacing:-.01em}',
+    'h3{font-size:1.13em}h4,h5,h6{font-size:1em}',
+    'h1,h2{padding-bottom:.3em;border-bottom:1px solid var(--line)}',
+    'body>*:first-child{margin-top:0}',
+    'p{margin:0 0 1em}',
+    'a{color:var(--accent)}',
+    'strong{font-weight:600}',
+    'ul,ol{margin:0 0 1em;padding-left:1.6em}li{margin:.25em 0}',
+    'li>p{margin:0}',
+    'blockquote{margin:0 0 1em;padding:.1px 0 .1px 1em;border-left:3px solid var(--line);color:var(--ink-2)}',
+    'hr{border:0;border-top:1px solid var(--line);margin:1.8em 0}',
+    "code{font-family:ui-monospace,'SF Mono',Menlo,monospace;font-size:.88em;",
+    'background:var(--panel);border:1px solid var(--line);border-radius:4px;padding:.12em .35em}',
+    'pre{background:var(--panel);border:1px solid var(--line);border-radius:6px;',
+    'padding:12px 14px;overflow:auto;margin:0 0 1em}',
+    'pre code{background:none;border:0;padding:0;font-size:.85em;line-height:1.55}',
+    'table{border-collapse:collapse;margin:0 0 1em;display:block;overflow:auto;max-width:100%}',
+    'th,td{border:1px solid var(--line);padding:.42em .75em;text-align:left}',
+    'th{background:var(--panel);font-weight:600}',
+    'del{color:var(--ink-3)}'
+  ].join('');
+
+  // Markdown is rendered by building HTML here and handing it to renderHtml(),
+  // so it lands in the same opaque-origin, CSP-restricted frame an HTML document
+  // already gets. Nothing below passes source through: every span of text is
+  // escaped before any tag is emitted, so a document containing a raw <script>
+  // shows the tag as text instead of running it.
+  function mdEscape(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  // The frame allows scripts, so a javascript: href would run inside it. Only
+  // schemes a reader can act on survive; anything else renders as plain text.
+  // The input is already escaped, so quotes cannot break out of the attribute.
+  function mdHref(raw) {
+    var h = String(raw).trim();
+    return /^(https?:|mailto:)/i.test(h) || /^[#\\/]/.test(h) ? h : '';
+  }
+
+  function mdInline(s) {
+    // Code spans are lifted out before anything else and restored last, so their
+    // contents cannot be re-read as emphasis, links, or tags.
+    var code = [];
+    s = s.replace(/\`([^\`]+)\`/g, function (_, c) {
+      return '\\u0000' + (code.push(c) - 1) + '\\u0000';
+    });
+    s = mdEscape(s);
+    s = s.replace(/!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)/g, function (_, alt, src) {
+      // The frame's policy allows only data: and blob: images, so a remote one
+      // would silently fail to load. A link states what it is and still works.
+      var h = mdHref(src);
+      return h ? '<a href="' + h + '">' + (alt || 'image') + '</a>' : (alt || '');
+    });
+    s = s.replace(/\\[([^\\]]*)\\]\\(([^)\\s]+)\\)/g, function (_, txt, href) {
+      var h = mdHref(href);
+      return h ? '<a href="' + h + '">' + txt + '</a>' : txt;
+    });
+    s = s.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
+    s = s.replace(/~~([^~]+)~~/g, '<del>$1</del>');
+    s = s.replace(/\\*([^*\\n]+)\\*/g, '<em>$1</em>');
+    // _emphasis_ only at word boundaries, so snake_case_identifiers survive.
+    s = s.replace(/(^|[\\s(])_([^_\\n]+)_(?=[\\s).,;:!?]|$)/g, '$1<em>$2</em>');
+    return s.replace(/\\u0000(\\d+)\\u0000/g, function (_, n) {
+      return '<code>' + mdEscape(code[+n]) + '</code>';
+    });
+  }
+
+  function mdCells(row) {
+    return row.trim().replace(/^\\||\\|$/g, '').split('|').map(function (c) { return c.trim(); });
+  }
+
+  function mdBody(src) {
+    var lines = String(src).replace(/[\\u0000\\u0001]/g, '').replace(/\\r\\n?/g, '\\n').split('\\n');
+    var out = [], i = 0;
+    var STARTER = /^ {0,3}(#{1,6}\\s|>|\`\`\`|~~~|[-*+]\\s|\\d+[.)]\\s)/;
+
+    function list(ordered) {
+      var re = ordered ? /^ {0,3}\\d+[.)]\\s+(.*)$/ : /^ {0,3}[-*+]\\s+(.*)$/;
+      var items = [], m;
+      while (i < lines.length && (m = re.exec(lines[i]))) {
+        var item = [m[1]];
+        i++;
+        // Lines indented under the marker continue the same item.
+        while (i < lines.length && /^\\s{2,}\\S/.test(lines[i]) && !STARTER.test(lines[i])) {
+          item.push(lines[i].trim());
+          i++;
+        }
+        items.push('<li>' + mdInline(item.join(' ')) + '</li>');
+      }
+      var tag = ordered ? 'ol' : 'ul';
+      out.push('<' + tag + '>' + items.join('') + '</' + tag + '>');
+    }
+
+    while (i < lines.length) {
+      var line = lines[i], m;
+
+      if (!line.trim()) { i++; continue; }
+
+      if ((m = /^ {0,3}(\`\`\`+|~~~+)/.exec(line))) {
+        var close = new RegExp('^ {0,3}' + (m[1].charAt(0) === '~' ? '~~~' : '\`\`\`'));
+        var buf = [];
+        i++;
+        while (i < lines.length && !close.test(lines[i])) { buf.push(lines[i]); i++; }
+        i++;
+        out.push('<pre><code>' + mdEscape(buf.join('\\n')) + '</code></pre>');
+        continue;
+      }
+
+      if ((m = /^ {0,3}(#{1,6})\\s+(.*?)\\s*#*\\s*$/.exec(line))) {
+        out.push('<h' + m[1].length + '>' + mdInline(m[2]) + '</h' + m[1].length + '>');
+        i++;
+        continue;
+      }
+
+      if (/^ {0,3}([-*_])\\s*(\\1\\s*){2,}$/.test(line)) { out.push('<hr>'); i++; continue; }
+
+      // A table is a row of cells whose next line is the delimiter. Checking the
+      // delimiter — not just the presence of a pipe — keeps prose containing a
+      // vertical bar from being torn into columns.
+      if (line.indexOf('|') !== -1 && i + 1 < lines.length &&
+          /^[\\s|:-]+$/.test(lines[i + 1]) && lines[i + 1].indexOf('-') !== -1) {
+        var head = mdCells(line);
+        var align = mdCells(lines[i + 1]).map(function (c) {
+          return /^:-+:$/.test(c) ? 'center' : /:$/.test(c) ? 'right' : '';
+        });
+        function cell(tag, c, n) {
+          return '<' + tag + (align[n] ? ' style="text-align:' + align[n] + '"' : '') + '>' +
+            mdInline(c) + '</' + tag + '>';
+        }
+        i += 2;
+        var rows = [];
+        while (i < lines.length && lines[i].trim() && lines[i].indexOf('|') !== -1) {
+          rows.push('<tr>' + mdCells(lines[i]).map(function (c, n) {
+            return cell('td', c, n);
+          }).join('') + '</tr>');
+          i++;
+        }
+        out.push('<table><thead><tr>' +
+          head.map(function (c, n) { return cell('th', c, n); }).join('') +
+          '</tr></thead><tbody>' + rows.join('') + '</tbody></table>');
+        continue;
+      }
+
+      if (/^ {0,3}>/.test(line)) {
+        var quote = [];
+        while (i < lines.length && /^ {0,3}>/.test(lines[i])) {
+          quote.push(lines[i].replace(/^ {0,3}>\\s?/, ''));
+          i++;
+        }
+        out.push('<blockquote>' + mdBody(quote.join('\\n')) + '</blockquote>');
+        continue;
+      }
+
+      if (/^ {0,3}[-*+]\\s+/.test(line)) { list(false); continue; }
+      if (/^ {0,3}\\d+[.)]\\s+/.test(line)) { list(true); continue; }
+
+      var para = [];
+      while (i < lines.length && lines[i].trim() && !STARTER.test(lines[i])) {
+        para.push(lines[i]);
+        i++;
+      }
+      // A newline inside a paragraph is a soft break: it is there so the source
+      // could be hard-wrapped, and a reader expects the text to reflow to their
+      // own width. Only the explicit forms — two trailing spaces, or a trailing
+      // backslash — force a line break. The sentinel survives escaping and is
+      // stripped from the input above, so a document cannot forge one.
+      var joined = '';
+      for (var p = 0; p < para.length; p++) {
+        if (p === para.length - 1) { joined += para[p]; break; }
+        joined += /(  |\\\\)$/.test(para[p])
+          ? para[p].replace(/(\\s+|\\\\)$/, '') + '\\u0001'
+          : para[p].replace(/\\s+$/, '') + ' ';
+      }
+      out.push('<p>' + mdInline(joined).replace(/\\u0001/g, '<br>') + '</p>');
+    }
+    return out.join('\\n');
+  }
+
+  function mdToHtml(src) {
+    return '<!DOCTYPE html><html><head><meta charset="utf-8"><style>' + MD_CSS +
+      '</style></head><body>' + mdBody(src) + '</body></html>';
+  }
+
   function renderHtml(html) {
     var frame = document.createElement('iframe');
     // allow-scripts WITHOUT allow-same-origin: the frame gets a unique opaque
@@ -1357,8 +1552,15 @@ Protocol, key schedule and setup: https://vnsh.dev/llms.txt
   }
 
   function render() {
-    if (!showingSource && looksLikeHtml(plaintext)) renderHtml(plaintext);
-    else renderText(plaintext);
+    // Rendered vs source is one binary choice; only the default and the renderer
+    // differ by content type. HTML opens rendered because that is what its author
+    // wrote it for. Everything else opens as source — the bytes are still the
+    // truth for a log or a config — and markdown rendering is one click away
+    // rather than guessed at, since no heuristic separates a markdown document
+    // from a shell script whose first line begins with a hash.
+    if (showingSource) renderText(plaintext);
+    else if (looksLikeHtml(plaintext)) renderHtml(plaintext);
+    else renderHtml(mdToHtml(plaintext));
   }
 
   async function main() {
@@ -1494,14 +1696,17 @@ Protocol, key schedule and setup: https://vnsh.dev/llms.txt
       URL.revokeObjectURL(a.href);
     };
 
-    if (looksLikeHtml(plaintext)) {
-      raw.hidden = false;
-      raw.onclick = function () {
-        showingSource = !showingSource;
-        raw.textContent = showingSource ? 'View page' : 'View source';
-        render();
-      };
-    }
+    // Every document can be shown both ways now, so the toggle is always offered.
+    var isHtml = looksLikeHtml(plaintext);
+    var renderedLabel = isHtml ? 'View page' : 'View rendered';
+    showingSource = !isHtml;
+    raw.hidden = false;
+    raw.textContent = showingSource ? renderedLabel : 'View source';
+    raw.onclick = function () {
+      showingSource = !showingSource;
+      raw.textContent = showingSource ? renderedLabel : 'View source';
+      render();
+    };
 
     render();
   }

--- a/worker/test/markdown.test.ts
+++ b/worker/test/markdown.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import worker from '../src/index';
+
+type Env = { VNSH_STORE: R2Bucket };
+
+/**
+ * The markdown renderer ships inside the viewer's inline script, so a copy of it
+ * here would be a second implementation free to drift from the one users get.
+ * Instead the block is lifted out of the page the worker actually serves and
+ * evaluated, which means these assertions run against shipped code and the
+ * extraction fails loudly if the block is moved or renamed.
+ */
+let mdBody: (src: string) => string;
+let page = '';
+
+beforeAll(async () => {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request('http://localhost/w/aBcDeFgHiJkL'), env as Env, ctx);
+  await waitOnExecutionContext(ctx);
+  page = await res.text();
+
+  const start = page.indexOf('var MD_CSS = [');
+  const end = page.indexOf('function renderHtml(');
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  mdBody = new Function(page.slice(start, end) + ';return mdBody;')() as typeof mdBody;
+});
+
+describe('markdown rendering', () => {
+  describe('blocks', () => {
+    it('renders ATX headings at their level', () => {
+      expect(mdBody('# One')).toContain('<h1>One</h1>');
+      expect(mdBody('### Three')).toContain('<h3>Three</h3>');
+    });
+
+    it('renders fenced code without interpreting what is inside', () => {
+      const out = mdBody('```\n**not bold**\n```');
+      expect(out).toContain('<pre><code>');
+      expect(out).toContain('**not bold**');
+      expect(out).not.toContain('<strong>');
+    });
+
+    it('renders unordered and ordered lists', () => {
+      expect(mdBody('- a\n- b')).toBe('<ul><li>a</li><li>b</li></ul>');
+      expect(mdBody('1. a\n2. b')).toBe('<ol><li>a</li><li>b</li></ol>');
+    });
+
+    it('renders a GFM table with alignment', () => {
+      const out = mdBody('| a | b |\n| --- | ---: |\n| 1 | 2 |');
+      expect(out).toContain('<th>a</th>');
+      expect(out).toContain('style="text-align:right"');
+      expect(out).toContain('<td>1</td>');
+    });
+
+    it('leaves prose containing a pipe alone', () => {
+      // Without the delimiter-row check, this would be torn into columns.
+      const out = mdBody('use grep | wc to count');
+      expect(out).not.toContain('<table>');
+      expect(out).toContain('<p>');
+    });
+
+    it('renders nested blockquote content as blocks', () => {
+      expect(mdBody('> # quoted')).toBe('<blockquote><h1>quoted</h1></blockquote>');
+    });
+
+    it('renders a horizontal rule', () => {
+      expect(mdBody('---')).toBe('<hr>');
+    });
+
+    it('reflows a hard-wrapped paragraph instead of preserving the wrap', () => {
+      // Source wrapped at some column should not reach the reader wrapped at
+      // that column. A single newline is a soft break.
+      expect(mdBody('one\ntwo')).toBe('<p>one two</p>');
+      expect(mdBody('one\ntwo')).not.toContain('<br>');
+    });
+
+    it('honours the explicit hard-break forms', () => {
+      expect(mdBody('one  \ntwo')).toBe('<p>one<br>two</p>');
+      expect(mdBody('one\\\ntwo')).toBe('<p>one<br>two</p>');
+    });
+
+    it('does not let the document forge a line break', () => {
+      // The sentinel used to mark hard breaks is stripped from the input.
+      expect(mdBody('a\u0001b')).toBe('<p>ab</p>');
+    });
+  });
+
+  describe('inline', () => {
+    it('renders emphasis and strong', () => {
+      expect(mdBody('**b** and *i*')).toContain('<strong>b</strong>');
+      expect(mdBody('**b** and *i*')).toContain('<em>i</em>');
+    });
+
+    it('leaves snake_case identifiers intact', () => {
+      // Underscore emphasis at word boundaries only, or every identifier in a
+      // technical document would sprout italics.
+      expect(mdBody('call some_var_name now')).toContain('some_var_name');
+      expect(mdBody('call some_var_name now')).not.toContain('<em>');
+    });
+
+    it('does not re-read the inside of a code span', () => {
+      const out = mdBody('`a_b_c **d**`');
+      expect(out).toContain('<code>a_b_c **d**</code>');
+      expect(out).not.toContain('<strong>');
+    });
+
+    it('renders links', () => {
+      expect(mdBody('[x](https://example.com)')).toContain('<a href="https://example.com">x</a>');
+    });
+  });
+
+  describe('untrusted input', () => {
+    it('escapes tags rather than emitting them', () => {
+      const out = mdBody('<script>alert(1)</script>');
+      expect(out).not.toContain('<script>');
+      expect(out).toContain('&lt;script&gt;');
+    });
+
+    it('drops a javascript: href but keeps the text', () => {
+      // The frame allows scripts, so an unfiltered href would run in it.
+      const out = mdBody('[click](javascript:alert(1))');
+      expect(out).not.toContain('javascript:');
+      expect(out).not.toContain('<a ');
+      expect(out).toContain('click');
+    });
+
+    it('drops a data: href', () => {
+      const out = mdBody('[x](data:text/html,<script>alert(1)</script>)');
+      expect(out).not.toContain('<a ');
+    });
+
+    it('cannot break out of an href attribute', () => {
+      const out = mdBody('[x](https://e.com/"onmouseover="alert(1))');
+      expect(out).not.toContain('onmouseover="alert');
+    });
+
+    it('renders an image as a link, since the frame policy blocks remote images', () => {
+      const out = mdBody('![alt](https://example.com/a.png)');
+      expect(out).toContain('<a href="https://example.com/a.png">alt</a>');
+      expect(out).not.toContain('<img');
+    });
+  });
+
+  describe('the served page', () => {
+    it('carries the renderer and its stylesheet', () => {
+      expect(page).toContain('function mdToHtml(');
+      expect(page).toContain('var MD_CSS = [');
+    });
+
+    it('offers the view toggle for every document, not only HTML', () => {
+      // Previously the button was revealed inside an `if (looksLikeHtml(...))`,
+      // which left plain-text documents with no way to ask for a rendered view.
+      expect(page).toContain("var renderedLabel = isHtml ? 'View page' : 'View rendered';");
+      expect(page).toContain('raw.hidden = false;');
+    });
+
+    it('routes markdown through the same hardened frame as HTML', () => {
+      expect(page).toContain('else renderHtml(mdToHtml(plaintext));');
+    });
+  });
+});


### PR DESCRIPTION
Closes #33.

## The problem

`render()` branched twice — content that looks like HTML went to the hardened
frame, everything else to a `<pre>` — and no markdown library was loaded on the
page. So a `.md` document displayed as monospace source while an HTML document
got the good view.

That inverts the common case. The stated primary authors are agents, the format
agents emit by default for notes, plans and handoffs is markdown, and a
recipient's first impression of vnsh is usually a link someone handed them.

## What this does

Adds a dependency-free renderer to the viewer's inline script — headings, fenced
code, lists, blockquotes, GFM tables with alignment, thematic breaks, and inline
emphasis, strikethrough, code spans and links.

Its output goes through the existing `harden()` and into the same iframe an HTML
document already gets, so **there is no new attack surface**: worst case, raw
HTML embedded in a markdown document ends up exactly where an HTML document
ends up today. On top of that the renderer builds HTML rather than passing any
through — every span of text is escaped before a tag is emitted — and hrefs are
limited to `http:`, `https:`, `mailto:` and same-document refs, so a
`javascript:` link renders as inert text rather than running in a frame that
allows scripts. Remote images are rendered as links, since the injected policy
allows only `data:` and `blob:` and a real `<img>` would just fail to load.

The stylesheet is inline and uses the viewer's own palette, so rendered content
reads as part of the page rather than something bolted into a frame.

## What this deliberately does not do

**Defaults are unchanged.** HTML still opens rendered; everything else still
opens as source. The change is that the existing view control is now offered for
every document instead of only for HTML, so a reader can *ask* for the rendered
view.

**No auto-detection.** Per the discussion in #33: no heuristic separates a
markdown document from a shell script whose first line begins with a hash, and
promoting `#!/usr/bin/env` to an `<h1>` is worse than one click. Making rendered
the default wants a writer-declared content kind — a header on PUT, mirrored on
GET the way `X-Vnsh-Public` already is — which is a protocol change and belongs
in its own PR. This one is additive and cannot regress an existing document.

**The v1 blob viewer is untouched.**

## Incidental fix

Paragraphs now reflow on soft breaks, as CommonMark specifies; only two trailing
spaces or a trailing backslash force a line break. A hard-wrapped source document
was previously reaching readers wrapped at the author's column.

## Testing

`worker/test/markdown.test.ts`, 22 cases. Rather than copying the renderer into
the test file — where it would become a second implementation free to drift, the
concern raised in #21 — the tests lift the block out of the page the worker
actually serves and evaluate it. They exercise shipped code, and the extraction
fails loudly if the block is moved or renamed.

Coverage includes the untrusted-input cases (tag escaping, `javascript:` and
`data:` hrefs, attribute break-out), the ones that are easy to get wrong
(`snake_case` surviving underscore emphasis, code spans not being re-parsed,
prose containing a pipe not becoming a table), and the soft/hard break rules.

Full worker suite: 166 passing, up from 144.
