### PR TITLE
Document workspace creation, the public write link, and the User-Agent challenge in llms.txt

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2853,6 +2853,46 @@ X-Vnsh-Public: 1, the body is already plaintext — do not try to decrypt it.
 To create one, add X-Vnsh-Public: 1 to the create request, or run vn --public.
 Encrypted remains the default everywhere; public is never inferred.
 
+Public changes how the content is stored, not how writing is authorised. A
+write still needs the token derived from S, and /p/{id} has no fragment to
+carry it, so a public workspace is addressed two ways and only one of them can
+be handed out:
+
+  https://vnsh.dev/p/{id}                    share this — no key, nothing to lose
+  https://vnsh.dev/w/{id}#w=<base64url(S)>   keep this — the only way to write again
+
+Surface both when you create one. An implementation that shows only the public
+link has silently given up the ability to update its own document.
+
+## Creating a workspace
+
+The server is told the hash of the write token and never the token itself,
+which is what leaves it unable to author a write of its own.
+
+  S = 32 random bytes                                        # the root secret
+  K = HKDF-SHA256(ikm=S, salt="", info="vnsh/enc/v2", 32)    # content key
+  W = HKDF-SHA256(ikm=S, salt="", info="vnsh/write/v2", 32), hex-encoded
+
+  POST https://vnsh.dev/api/workspace
+    X-Vnsh-Write-Hash: <SHA-256 of W, as 64 hex chars>   required
+    X-Vnsh-Public: 1                                     optional, see above
+    body: nonce(12) || AES-256-GCM(K, nonce, content)
+          — or the content as plaintext, if the workspace is public
+
+  → 201 {"id": "…", "version": 1, "expires": "…", "public": false}
+
+The body is the first version, so creating a workspace and writing its opening
+content is one request, not two. Maximum 25 MB.
+
+Note the asymmetry when you write again: the create response reports the
+version in its JSON body and sends no ETag, while GET returns one and PUT
+expects it back as If-Match. Take the number from wherever you last saw it.
+
+Then build the links from S:
+
+  https://vnsh.dev/w/{id}#w=<base64url(S)>   read + write
+  https://vnsh.dev/w/{id}#r=<base64url(K)>   read only
+
 ## Reading a workspace without vnsh tooling
 
 The key is in the fragment, so an HTTP fetch alone never returns anything
@@ -2871,6 +2911,11 @@ To write, you also need the write token:
 
 A PUT without If-Match is refused, so one agent cannot silently overwrite
 another's work. On 412, re-read, merge, and retry.
+
+Send a User-Agent on every request. The edge in front of vnsh.dev challenges
+some libraries' default agent strings and answers 403 with an HTML error page
+instead of a JSON API error — which reads like a broken request rather than a
+bot check, and costs an implementer more time than it should.
 
 ## Why WebFetch alone will not work
 

--- a/worker/test/workspace.test.ts
+++ b/worker/test/workspace.test.ts
@@ -471,6 +471,42 @@ describe('agent setup prompt', () => {
     expect(llms).toContain('vnsh/enc/v2');
     expect(llms).toContain('If-Match');
   });
+
+  it('llms.txt documents creation, not only read and write', async () => {
+    const llms = await (await call(new Request('http://localhost/llms.txt'))).text();
+
+    // The document invites implementers to reimplement the protocol without vnsh
+    // tooling, so leaving out the one call that starts a workspace made that
+    // impossible to finish: the requirement below is only discoverable by
+    // sending a request and reading the 400.
+    expect(llms).toContain('POST https://vnsh.dev/api/workspace');
+    expect(llms).toContain('X-Vnsh-Write-Hash');
+    expect(llms).toContain('vnsh/write/v2');
+
+    // The create response reports the version in JSON and sends no ETag, while
+    // PUT wants it back as If-Match. Silence about that costs a round of
+    // debugging.
+    expect(llms).toMatch(/create response[\s\S]{0,80}ETag/);
+  });
+
+  it('llms.txt says a public workspace keeps its write link elsewhere', async () => {
+    const llms = await (await call(new Request('http://localhost/llms.txt'))).text();
+
+    // /p/{id} carries no fragment, so an implementation that surfaces only the
+    // public link cannot write to its own document ever again. The web client
+    // already returns both; the spec had not said so.
+    expect(llms).toContain('https://vnsh.dev/p/{id}');
+    expect(llms).toMatch(/only way to write again/);
+  });
+
+  it('llms.txt warns that a default User-Agent can be challenged', async () => {
+    const llms = await (await call(new Request('http://localhost/llms.txt'))).text();
+
+    // The edge answers with an HTML error page, which reads as a broken request
+    // rather than a bot check — worth one sentence to save an implementer the
+    // detour.
+    expect(llms).toContain('User-Agent');
+  });
 });
 
 describe('homepage information architecture', () => {


### PR DESCRIPTION
Three gaps found while implementing the protocol from `llms.txt` alone, in a
language with no vnsh client. All three are documentation; two of them are
things the codebase already gets right and only the spec was silent about.

## 1. Creation was not documented at all

`llms.txt` says an implementer should be able to work without vnsh tooling, and
then documents `GET` and `PUT` of a workspace that already exists. The call that
creates one is absent, as is the header it requires — so `X-Vnsh-Write-Hash` is
discoverable only by sending a request and reading the 400.

Adds a **Creating a workspace** section: key schedule, the `POST` contract, the
25 MB limit, the 201 shape. Two things worth stating that a reader would
otherwise get wrong:

- The body *is* the first version, so creating and writing the opening content
  is one request. An implementer guessing will do `POST` then `PUT` and pay an
  extra round trip.
- The create response reports `version` in its JSON and sends **no** `ETag`,
  while `GET` returns one and `PUT` expects it back as `If-Match`.

## 2. A public workspace's write link was never mentioned

`/p/{id}` carries no fragment, and public changes how content is stored rather
than how writing is authorised — a write still needs the token derived from the
root secret. So a public workspace is addressed two ways, and only one of them
is shareable.

**The web client already returns both** (`createWorkspace()` returns `edit` as a
`/w/` link alongside the public `view`), and the viewer has a comment noting a
public workspace has a `/w/` edit link. The spec is where it goes unsaid, which
is exactly where someone implementing from the spec will surface only the public
link and quietly lose write access to their own document. This adds the two-line
table and one sentence telling implementers to surface both.

## 3. A default User-Agent gets challenged

The edge answers some libraries' default agent strings with a 403 and an HTML
error page instead of a JSON API error. It reads as a broken request rather than
a bot check, and it lands on the most likely language for a from-the-spec
implementation. One sentence in the reading section.

Worth noting this one is only half fixable here — the durable fix is edge
configuration, outside this repo. The sentence keeps it from costing anyone an
afternoon in the meantime.

## Tests

Three cases added alongside the existing `llms.txt` assertions in
`worker/test/workspace.test.ts`, following the same shape. 147 passing, up from
144.

Independent of #34 — different section of the file, no conflict.
